### PR TITLE
Fixed directories having a file extension

### DIFF
--- a/src/include/scalar_functions/file_utils.hpp
+++ b/src/include/scalar_functions/file_utils.hpp
@@ -68,7 +68,12 @@ namespace duckdb {
         UnaryExecutor::Execute<string_t, string_t>(
                 path_vector, result, input.size(),
                 [&](string_t path) {
-                    return StringVector::AddString(result, fs::path(path.GetString()).extension().string());
+                    std::string path_str = path.GetString();
+                    if (fs::is_directory(path_str)) {
+                        return StringVector::AddString(result, "");
+                    }else{
+                        return StringVector::AddString(result, fs::path(path_str).extension().string());
+                    }
                 });
     }
 


### PR DESCRIPTION
Folders should not be able to have file extensions.
This PR fixes this by setting the file extensions of folders to an empty string.